### PR TITLE
Fixed errors for plotting Ichimoku

### DIFF
--- a/TAcharts/indicators/ichimoku.py
+++ b/TAcharts/indicators/ichimoku.py
@@ -55,8 +55,8 @@ class Ichimoku:
 
     def _build_lines(self, **kwargs):
         for key, val in kwargs.items():
-            high = sma(self.df["high"], val, "max")
-            low = sma(self.df["low"], val, "min")
+            high = sma(self.df["high"], val)
+            low = sma(self.df["low"], val)
             self.ichimoku[key] = (high + low) / 2
         return
 

--- a/TAcharts/wrappers.py
+++ b/TAcharts/wrappers.py
@@ -27,11 +27,13 @@ def pd_series_to_np_array(fn):
     def wrapper(*args, **kwargs):
         if isinstance(args[0], pd.Series):
             oldSeries = args[0].copy()
+            is_oldSeries = oldSeries.any()
         else:
             oldSeries = None
+            is_oldSeries = None
 
         args = tuple(x if type(x) != pd.Series else args[0].to_numpy(na_value=0) for x in args)
-        if oldSeries:
+        if is_oldSeries:
             return pd.Series(data=fn(*args, **kwargs), index=oldSeries.index)
         else:
             return fn(*args, **kwargs)


### PR DESCRIPTION
Modifications related to the following issue:
https://github.com/cartercarlson/TAcharts/issues/16

Changed pd_series_to_np_array decorator inside wrappers.py
if condition applied to a pd.Series object raised an exception. The condition now checks on a new object.

Additionally, changed _build_lines method in Ichimoku class (ichimoku.py). It was originally calling sma() function with 3 arguments, when the function only expects 2. Removed the 3rd argument as it didn't seem to do anything.